### PR TITLE
Fix links visible in spoiler sections

### DIFF
--- a/override-markdown-styles.css
+++ b/override-markdown-styles.css
@@ -133,7 +133,9 @@ blockquote {
 	vertical-align: -15%;
 }
 
-.hidden {
+.hidden,
+.hidden a,
+.hidden a:visited {
 	color: black;
 	background-color: black;
 }


### PR DESCRIPTION
Currently if the blacked-out spoiler section contains a link, the blue text will be visible.

<img width="821" alt="image" src="https://github.com/user-attachments/assets/1ba4125d-b606-4504-9b5e-52849929aa89">

<img width="788" alt="image" src="https://github.com/user-attachments/assets/94071a4a-46f1-4a1f-a1c1-35d00ee3375e">

This PR addresses that, by changing link text inside of hidden section to black as well:

<img width="773" alt="image" src="https://github.com/user-attachments/assets/89795b73-6d39-40de-884e-0f4a9248cb9b">
